### PR TITLE
Deprecate theme component in favour of hide-auth-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+DEPRECATED - please switch to discourse-hide-auth-method https://meta.discourse.org/t/227584

--- a/common/header.html
+++ b/common/header.html
@@ -16,4 +16,24 @@
       }
     }
   );
+
+  const getURL = require("discourse-common/lib/get-url").default;
+
+  if (api.getCurrentUser()?.admin) {
+    const themeId = themePrefix("foo").match(
+      /theme_translations\.(\d+)\.foo/
+    )[1];
+    const themeURL = getURL(`/admin/customize/themes/${themeId}`);
+
+    api.addGlobalNotice(
+      `<b>Admin notice:</b> you're using the <em>discourse-excluded-logins</em> theme component. This has been deprecated in favour of <a href="https://meta.discourse.org/t/227584">discourse-hide-auth-method</a>. You should switch and then <a href="${themeURL}">remove this theme component</a>.`,
+      "loading-slider-theme",
+      {
+        dismissable: true,
+        level: "warn",
+        dismissDuration: moment.duration("1", "hour"),
+      }
+    );
+  }
+
 </script>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  theme_metadata:
+    description: DEPRECATED - please switch to discourse-hide-auth-method https://meta.discourse.org/t/227584


### PR DESCRIPTION
<img width="1096" alt="SCR-20230830-nhga" src="https://github.com/discourse/discourse-excluded-logins/assets/6270921/c3982022-c628-4d2e-b672-b07ce5003825">
